### PR TITLE
Fix Serialization for Kotlin instant

### DIFF
--- a/src/models/ParticipantGroups.ts
+++ b/src/models/ParticipantGroups.ts
@@ -41,11 +41,7 @@ export interface ParticipantData {
   lastName: string;
   email: string;
   role: string;
-  dateOfLastDataUpload: {
-    epocSeconds: number;
-    'value$kotlinx_datetime': Date;
-    nanosecondsOfSecond: number;
-  };
+  dateOfLastDataUpload: Date;
 }
 
 export interface ParticipantStatus {

--- a/src/models/StudyOverview.ts
+++ b/src/models/StudyOverview.ts
@@ -1,11 +1,7 @@
 export type StudyOverview = {
   studyId: string;
   name: string;
-  createdOn: {
-    epocSeconds: number;
-    value$kotlinx_datetime: Date;
-    nanosecondsOfSecond: number;
-  };
+  createdOn: Date;
   studyProtocolId: string | null;
   canSetInvitation: boolean;
   canSetStudyProtocol: boolean;


### PR DESCRIPTION
After the backend switches to kotlinx.serialization, or more precisely, handle Kotlin Instant in the correct way, we don't need the Jackson default generated values.

I'm not sure how it works from mapping Kotlin/Java Instant to TS Date, I've tested with using imported kotlin.instant from generated Kotlin Javascript library and it works fine, but since there are other functionality we rely on in the portal to use Date, I did not make the change.